### PR TITLE
Fix deprecation warning for legacy env var reference

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -90,7 +90,7 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerProvider("anthropic-vertex", {
     baseUrl: `https://${region}-aiplatform.googleapis.com`,
-    apiKey: "GOOGLE_CLOUD_PROJECT",
+    apiKey: "$GOOGLE_CLOUD_PROJECT",
     api: "anthropic-vertex",
     models,
     streamSimple: (


### PR DESCRIPTION
Use explicit `$VARIABLE` env var reference, instead of the legacy `VARIABLE` for the `GOOGLE_CLOUD_PROJECT` variable.

Fixes #12