### PR TITLE
feat: support ANTHROPIC_VERTEX_PROJECT_ID for project resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ export GOOGLE_CLOUD_PROJECT=your-project-id
 export GOOGLE_CLOUD_LOCATION=us-east5  # optional, defaults to us-east5
 ```
 
+The extension also recognizes `ANTHROPIC_VERTEX_PROJECT_ID` and `GOOGLE_CLOUD_PROJECT_ID` for project resolution, and `CLOUD_ML_REGION` for region. This allows it to work with existing Claude Code setups without additional configuration.
+
 ## Usage
 
 ```bash

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@
  *
  * Prerequisites:
  *   1. gcloud auth application-default login
- *   2. export GOOGLE_CLOUD_PROJECT=your-project-id
+ *   2. export GOOGLE_CLOUD_PROJECT=your-project-id  (or ANTHROPIC_VERTEX_PROJECT_ID)
  *   3. export GOOGLE_CLOUD_LOCATION=us-east5  (optional, defaults to us-east5)
  *
  * Usage:
@@ -49,16 +49,20 @@ import {
   clampMaxTokensToContext,
 } from "./simple-options.ts";
 
-const project = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
+const project =
+  process.env.GOOGLE_CLOUD_PROJECT ||
+  process.env.GCLOUD_PROJECT ||
+  process.env.ANTHROPIC_VERTEX_PROJECT_ID ||
+  process.env.GOOGLE_CLOUD_PROJECT_ID;
 const region =
-  process.env.GOOGLE_CLOUD_LOCATION ||
   process.env.CLOUD_ML_REGION ||
+  process.env.GOOGLE_CLOUD_LOCATION ||
   "us-east5";
 
 export default function (pi: ExtensionAPI) {
   if (!project) {
     console.warn(
-      "[pi-anthropic-vertex] disabled: GOOGLE_CLOUD_PROJECT is not set",
+      "[pi-anthropic-vertex] disabled: set GOOGLE_CLOUD_PROJECT or ANTHROPIC_VERTEX_PROJECT_ID",
     );
     return;
   }
@@ -96,7 +100,7 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerProvider("anthropic-vertex", {
     baseUrl: `https://${region}-aiplatform.googleapis.com`,
-    apiKey: "$GOOGLE_CLOUD_PROJECT",
+    apiKey: project,
     api: "anthropic-vertex",
     models,
     streamSimple: (


### PR DESCRIPTION
This PR adds support for `ANTHROPIC_VERTEX_PROJECT_ID` as a fallback when resolving the GCP project, aligning with the official `@anthropic-ai/vertex-sdk` and the upcoming native `anthropic-vertex` provider in pi ([PR #5262](https://github.com/earendil-works/pi/pull/5262)).

### Problem

Users coming from Claude Code typically only have `ANTHROPIC_VERTEX_PROJECT_ID` set in their environment. The extension currently requires `GOOGLE_CLOUD_PROJECT`, forcing users to add a redundant env var pointing to the same project.

### Changes

**Project resolution** — added two fallbacks after the existing variables:

```
GOOGLE_CLOUD_PROJECT → GCLOUD_PROJECT → ANTHROPIC_VERTEX_PROJECT_ID → GOOGLE_CLOUD_PROJECT_ID
```

**Region resolution** — swapped priority to match the official Anthropic Vertex SDK convention:

```
CLOUD_ML_REGION → GOOGLE_CLOUD_LOCATION → us-east5
```

**apiKey** — pass the resolved `project` string directly instead of `"$GOOGLE_CLOUD_PROJECT"`, which would fail when the project was resolved from a different env var.

### References

- **Official `@anthropic-ai/vertex-sdk`** uses `ANTHROPIC_VERTEX_PROJECT_ID` for project and `CLOUD_ML_REGION` for region — see [`client.ts`](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/packages/vertex-sdk/src/client.ts)
- **Anthropic docs**: [Claude on Vertex AI](https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai)
- **Pi native provider PR** [#5262](https://github.com/earendil-works/pi/pull/5262) uses the same resolution order: `GOOGLE_CLOUD_PROJECT → GCLOUD_PROJECT → ANTHROPIC_VERTEX_PROJECT_ID → GOOGLE_CLOUD_PROJECT_ID`

### Testing

- All existing tests pass
- Tested locally with `GOOGLE_CLOUD_PROJECT` unset and only `ANTHROPIC_VERTEX_PROJECT_ID` set — provider registers and responds correctly