### PR TITLE
docs: note PI WEB non-interactive shell env var quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ pi --provider anthropic-vertex --model claude-sonnet-4-6
 
 All Claude models available on Vertex AI are registered automatically.
 
+## PI WEB
+
+[PI WEB](https://pi-web.dev) runs its session daemon through a non-interactive login
+shell, which does not source `~/.zshrc` (or bash's `~/.bashrc`). Make sure
+`GOOGLE_CLOUD_PROJECT` (or `ANTHROPIC_VERTEX_PROJECT_ID`) and related env vars are set
+in a file your shell sources for non-interactive login shells too, such as `~/.zprofile`
+for zsh or `~/.bash_profile` for bash.
+
+To check what the session daemon actually sees, restart it and inspect the log:
+
+```bash
+systemctl --user restart pi-web-sessiond
+journalctl --user -u pi-web-sessiond -n 50 --no-pager | grep pi-anthropic-vertex
+```
+
+A `[pi-anthropic-vertex] disabled: set GOOGLE_CLOUD_PROJECT or ANTHROPIC_VERTEX_PROJECT_ID`
+line means the env vars weren't visible to that process.
+
 ## License
 
 MIT


### PR DESCRIPTION
Fixes #25.

PI WEB's session daemon runs through a non-interactive login shell, which does not source `~/.zshrc` (or bash's `~/.bashrc`). If the env vars this extension needs (`GOOGLE_CLOUD_PROJECT`, `ANTHROPIC_VERTEX_PROJECT_ID`, etc.) only live in those interactive-only files, the provider silently fails to register at daemon startup and no Vertex models show up in PI WEB, even though the CLI works fine.

This adds a short README section explaining the cause and how to check it (`journalctl --user -u pi-web-sessiond`), and points to moving the env vars into a login-shell file like `~/.zprofile` / `~/.bash_profile`.

Root-caused and verified against a live PI WEB install (systemd `pi-web-sessiond`), confirmed with a clean-env `zsh -lc` reproduction before and after moving the vars.