### PR TITLE
fix: strip allowedFallbackModels so Vertex accepts requests

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { createVertexClientOpts } from "./index.ts";
+import type { Api, Model } from "@earendil-works/pi-ai/compat";
+import { createVertexClientOpts, stripFallbacks } from "./index.ts";
 
 describe("createVertexClientOpts", () => {
   it("sets interleaved-thinking header for non-adaptive model with no request headers", () => {
@@ -114,5 +115,32 @@ describe("createVertexClientOpts", () => {
     );
     assert.equal(opts.projectId, "my-project");
     assert.equal(opts.region, "europe-west1");
+  });
+});
+
+describe("stripFallbacks", () => {
+  it("removes allowedFallbackModels and keeps the other compat fields", () => {
+    // Shape of claude-opus-5 in pi's first-party Anthropic catalog.
+    const input = {
+      forceAdaptiveThinking: true,
+      supportsTemperature: false,
+      allowedFallbackModels: [
+        { provider: "anthropic", model: "claude-opus-4-8" },
+      ],
+    } as unknown as Model<Api>["compat"];
+
+    assert.deepEqual(stripFallbacks(input), {
+      forceAdaptiveThinking: true,
+      supportsTemperature: false,
+    });
+  });
+
+  it("leaves compat without allowedFallbackModels untouched", () => {
+    const compat = { forceAdaptiveThinking: true, supportsTemperature: false };
+    assert.deepEqual(stripFallbacks(compat), compat);
+  });
+
+  it("passes undefined compat through", () => {
+    assert.equal(stripFallbacks(undefined), undefined);
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -88,7 +88,7 @@ export default function (pi: ExtensionAPI) {
     }) => ({
       id,
       name,
-      compat,
+      compat: stripFallbacks(compat),
       reasoning,
       thinkingLevelMap,
       input,
@@ -125,6 +125,29 @@ export default function (pi: ExtensionAPI) {
       return anthropicApi.stream(patchedModel, context, anthropicOptions);
     },
   });
+}
+
+/**
+ * Drop `allowedFallbackModels` from a model's compat metadata.
+ *
+ * Pi turns `compat.allowedFallbackModels` into a `fallbacks` body param on the
+ * Anthropic Messages request (server-side refusal fallback, added in pi 0.84.3).
+ * Vertex does not implement that param and rejects the whole request with
+ * "fallbacks: Extra inputs are not permitted". Since we copy compat verbatim
+ * from pi's first-party Anthropic catalog, we have to strip the field here.
+ */
+export function stripFallbacks(
+  compat: Model<Api>["compat"],
+): Model<Api>["compat"] {
+  if (!compat || !("allowedFallbackModels" in compat)) return compat;
+  // Read structurally rather than through AnthropicMessagesCompat: the field
+  // only exists in the type from pi 0.84 on, and this package still builds
+  // against its declared peer floor.
+  const { allowedFallbackModels: _, ...rest } = compat as Record<
+    string,
+    unknown
+  >;
+  return rest as Model<Api>["compat"];
 }
 
 /**


### PR DESCRIPTION
Fixes #27.

## Problem

Since pi 0.84.3, every request to `anthropic-vertex/claude-opus-5` fails:

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"fallbacks: Extra inputs are not permitted"}}
```

pi 0.84.3 added server-side refusal fallback ([earendil-works/pi#8017](https://github.com/earendil-works/pi/issues/8017)). Its `anthropic-messages` request builder now sets a `fallbacks` body param whenever the model metadata carries `compat.allowedFallbackModels`:

```js
const allowedFallbackModels = model.compat?.allowedFallbackModels;
if (allowedFallbackModels && allowedFallbackModels.length > 0) {
  params.fallbacks = allowedFallbackModels.map((fallback) => ({ model: fallback.model }));
}
```

This extension copies `compat` verbatim from pi's first-party Anthropic catalog, so the field rides along to Vertex, which does not implement that param and rejects the request. In the current catalog two models carry it: `claude-opus-5` and `claude-fable-5`. `claude-opus-5` is a common default, so for many users the extension stopped working entirely.

There is no user-side workaround: `modelOverrides` accepts `compat`, but `allowedFallbackModels` is absent from the `compat` schema in `pi-coding-agent/dist/core/model-config.js`, so it cannot be cleared from `models.json`. Switching models is not always an option either, since `claude-opus-4-8` is not available in every Vertex project and region.

## Change

`stripFallbacks()` drops `allowedFallbackModels` from compat when the models are re-registered for Vertex. Everything else in the model metadata passes through unchanged.

The field is read structurally rather than through `AnthropicMessagesCompat`, because it only exists in that type from pi 0.84 on and this package still lints against its declared peer floor (`>=0.80.7`, currently resolving to pi-ai 0.80.10). Typing it directly fails `npm run lint`.

The fix is deliberately keyed on the field rather than on model IDs, so it also covers any future model the upstream catalog tags the same way.

## Verification

- `npm run ci` passes: `tsc --noEmit` clean, 12/12 tests, including 3 new ones for `stripFallbacks`.
- End to end against a live Vertex project (`claude-opus-5`, location `global`, pi 0.84.3): the 400 above before the change, and a normal completion after it.

## Notes

I did not touch `sync/`, since this is not a mirrored-source change. Happy to adjust the placement of the helper, the naming, or the comment wording to taste.
